### PR TITLE
removing console statements

### DIFF
--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -8,6 +8,7 @@ builder:
     afterTask: replaceVersion
     configuration:
       debug: true
+      removeConsoleStatements: true
       excludePatterns:
       - "lib/"
   - name: ui5-task-zipper

--- a/packages/ui5-app/webapp/controller/App.controller.js
+++ b/packages/ui5-app/webapp/controller/App.controller.js
@@ -5,6 +5,7 @@ sap.ui.define([
 
 	return Controller.extend("test.Sample.controller.App", {
 		onInit() {
+			console.log("Statement will be removed if transpile task is configured accordingly.")
 		}
 	});
 });

--- a/packages/ui5-task-transpile/README.md
+++ b/packages/ui5-task-transpile/README.md
@@ -13,6 +13,9 @@ npm install ui5-task-transpile --save-dev
 - debug: true|false  
 verbose logging
 
+- removeConsoleStatements: true|false  
+remove console statements while transpiling using [Babel plugin](https://babeljs.io/docs/en/babel-plugin-transform-remove-console)
+
 - excludePatterns: `String<Array>`  
 array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
 e.g. 3-rd party libs in `lib/*`
@@ -47,6 +50,7 @@ builder:
     afterTask: replaceVersion
     configuration:
       debug: true
+      removeConsoleStatements: true
       excludePatterns:
       - "lib/"
       - "another/dir/in/webapp"

--- a/packages/ui5-task-transpile/lib/transpile.js
+++ b/packages/ui5-task-transpile/lib/transpile.js
@@ -20,7 +20,14 @@ module.exports = function({workspace, dependencies, options}) {
             if (!(options.configuration && options.configuration.excludePatterns || []).some(pattern => resource.getPath().includes(pattern))) {
                 return resource.getString().then((value) => {
                     options.configuration && options.configuration.debug && log.info("Transpiling file " + resource.getPath());
+                    
+                    let plugins = [];
+                    if(options.configuration && options.configuration.removeConsoleStatements){
+                        plugins = ["transform-remove-console"];
+                    }
+
                     return babel.transformAsync(value, {
+                        plugins: plugins,
                         presets: [
                             ["@babel/preset-env", {
                                 "targets": {

--- a/packages/ui5-task-transpile/package.json
+++ b/packages/ui5-task-transpile/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.8.4",
     "@babel/plugin-transform-modules-commonjs": "^7.8.3",
     "@babel/preset-env": "^7.8.4",
-    "@ui5/logger": "^1.0.2"
+    "@ui5/logger": "^1.0.2",
+    "babel-plugin-transform-remove-console": "^6.9.4"
   }
 }


### PR DESCRIPTION
Hello,

sometimes I want to remove all console-statements from an application, before it is deployed. First I wanted to write a new task, but then I found out that there's a babel plugin. So I've extended `ui5-task-transpile`.

Happy to hear your feedback.

Best regards,
Lukas