### PR TITLE
New option in ui5-middleware-servestatic to use paths from .env file

### DIFF
--- a/packages/ui5-middleware-servestatic/README.md
+++ b/packages/ui5-middleware-servestatic/README.md
@@ -54,8 +54,7 @@ server:
     afterMiddleware: compression
     mountPath: /resources
     configuration:
-      rootPath: SAPUI5_SDK_1_60__RESOURCES
-      pathIsEnvVar: true
+      rootPath: ${env.SAPUI5_SDK_1_60__RESOURCES}
 ```
 ## How it works
 

--- a/packages/ui5-middleware-servestatic/README.md
+++ b/packages/ui5-middleware-servestatic/README.md
@@ -34,7 +34,7 @@ npm install ui5-middleware-servestatic --save-dev
 
 > As the devDependencies are not recognized by the UI5 tooling, they need to be listed in the `ui5 > dependencies` array. In addition, once using the `ui5 > dependencies` array you need to list all UI5 tooling relevant dependencies.
 
-2. configure it in `$yourapp/ui5.yaml`:
+2. configure it in `$yourapp/ui5.yaml`:  
 
 ```yaml
 server:
@@ -46,6 +46,17 @@ server:
       rootPath: "/Users/Me/upkg/sapui5-runtime-1.70/resources"
 ```
 
+Example which uses Environment Variables from `.env` file
+```yaml
+server:
+  customMiddleware:
+  - name: ui5-middleware-servestatic
+    afterMiddleware: compression
+    mountPath: /resources
+    configuration:
+      rootPath: SAPUI5_SDK_1_60__RESOURCES
+      pathIsEnvVar: true
+```
 ## How it works
 
 The middleware integrates [serve-static](https://github.com/expressjs/serve-static) to serve static resources from a specified `rootPath`.

--- a/packages/ui5-middleware-servestatic/lib/serveStatic.js
+++ b/packages/ui5-middleware-servestatic/lib/serveStatic.js
@@ -1,5 +1,6 @@
 let serveStatic = require('serve-static');
 const log = require("@ui5/logger").getLogger("server:custommiddleware:servestatic");
+require("dotenv").config();
 
 /**
  * Custom UI5 Server middleware example
@@ -17,6 +18,11 @@ const log = require("@ui5/logger").getLogger("server:custommiddleware:servestati
  * @returns {function} Middleware function to use
  */
 module.exports = function({resources, options}) {
-   options.configuration.debug ? log.info(`Starting static serve from ${options.configuration.rootPath}`) : null;
-   return serveStatic(options.configuration.rootPath);
+   const pathIsEnvVariable = options.configuration && options.configuration.pathIsEnvVar;
+   let rootPath = options.configuration.rootPath;
+   if (pathIsEnvVariable) {
+       rootPath = process.env[rootPath];
+   }
+   options.configuration.debug ? log.info(`Starting static serve from ${rootPath}`) : null;
+   return serveStatic(rootPath);
 };

--- a/packages/ui5-middleware-servestatic/lib/serveStatic.js
+++ b/packages/ui5-middleware-servestatic/lib/serveStatic.js
@@ -20,7 +20,13 @@ require("dotenv").config();
 module.exports = function({resources, options}) {
    const pathIsEnvVariable = options.configuration && options.configuration.pathIsEnvVar;
    let rootPath = options.configuration.rootPath;
+   if (!rootPath) {
+       throw new Error(`No Value for 'rootPath' supplied`);
+   }
    if (pathIsEnvVariable) {
+       if (!process.env.hasOwnProperty(rootPath)) {
+           throw new Error(`Environment Variable ${rootPath} was not found in .env file`);
+       }
        rootPath = process.env[rootPath];
    }
    options.configuration.debug ? log.info(`Starting static serve from ${rootPath}`) : null;

--- a/packages/ui5-middleware-servestatic/package.json
+++ b/packages/ui5-middleware-servestatic/package.json
@@ -13,7 +13,8 @@
   },
   "dependencies": {
     "@ui5/logger": "^1.0.2",
-    "serve-static": "^1.14.1"
+    "serve-static": "^1.14.1",
+    "dotenv": "^8.2.0"
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"


### PR DESCRIPTION
Hi @petermuessig,

I added a new config option called `pathIsEnvVar`. If this option is set to `true` it is expected that the `rootPath` variable contains an environment variable contained in a `.env` file.

This makes collaberation in a ui5 repository easier as the `ui5.yaml` does not have to be adjusted by every user locally - not all users store their static resources in the same path.

Regards
Ludwig