### PR TITLE
Support for environment variables and .env for baseUri and strictSSL

### DIFF
--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -11,7 +11,9 @@ npm install ui5-middleware-simpleproxy --save-dev
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
 - baseUri: `string`
-  the baseUri to proxy
+  The baseUri to proxy. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_BASEURI` environment variable.
+- strictSSL: `boolean`
+  Ignore strict SSL checks. Default value `true`. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_STRICT_SSL` environment variable.
 
 ## Usage
 
@@ -73,6 +75,15 @@ server:
     configuration:
       baseUri: "http://services.odata.org"
       strictSSL: false
+```
+
+## .env support
+
+This plugin supports use of a `.env` file to declare environment variable values for configuration as described above. The file should be put in the same directory where you run `ui5 build`, `ui5 serve`, etc. The file might have contents like:
+
+```shell
+UI5_MIDDLEWARE_SIMPLE_PROXY_BASEURI=https://host.tld:1234/sap
+UI5_MIDDLEWARE_SIMPLE_PROXY_STRICT_SSL=false
 ```
 
 ## License

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -15,6 +15,8 @@ npm install ui5-middleware-simpleproxy --save-dev
 - strictSSL: `boolean`
   Ignore strict SSL checks. Default value `true`. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_STRICT_SSL` environment variable.
 
+In general, use of environment variables or values set in a `.env` file will override configuration values in the `ui5.yaml`.
+
 ## Usage
 
 1. Define the dependency in `$yourapp/package.json`:

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -61,8 +61,6 @@ module.exports = function ({ resources, options }) {
     options.configuration ? options.configuration.strictSSL : undefined
   );
 
-  log.info(providedStrictSSL);
-
   /*
   return function (req, res, next) {
       // [...]

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -27,7 +27,16 @@ const env = {
 module.exports = function({resources, options}) {
     // Environment wins over YAML configuration when loading settings
     const providedBaseUri = env.baseUri || (options.configuration && options.configuration.baseUri);
-    const providedStrictSSL = env.strictSSL || (options.configuration && options.configuration.strictSSL);
+    // Handle fact that `strictSSL` is a boolean so we have to do existence checks
+    const falseyStrictSSL = 
+      (
+        env.strictSSL === undefined 
+        && options.configuration 
+        && options.configuration.strictSSL !== undefined 
+      )
+      ? options.configuration.strictSSL 
+      : env.strictSSL;
+    const providedStrictSSL = !!falseyStrictSSL;
 
     /*
     return function (req, res, next) {

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -25,8 +25,9 @@ const env = {
  * @returns {function} Middleware function to use
  */
 module.exports = function({resources, options}) {
-    const providedBaseUri = (options.configuration && options.configuration.baseUri) || env.baseUri;
-    const providedStrictSSL = (options.configuration && options.configuration.strictSSL) || env.strictSSL;
+    // Environment wins over YAML configuration when loading settings
+    const providedBaseUri = env.baseUri || (options.configuration && options.configuration.baseUri);
+    const providedStrictSSL = env.strictSSL || (options.configuration && options.configuration.strictSSL);
 
     /*
     return function (req, res, next) {

--- a/packages/ui5-middleware-simpleproxy/package.json
+++ b/packages/ui5-middleware-simpleproxy/package.json
@@ -16,6 +16,7 @@
     "express-http-proxy": "^1.6.0"
   },
   "devDependencies": {
+    "dotenv": "^8.2.0",
     "npm-check-updates": "^4.1.1"
   }
 }


### PR DESCRIPTION
This pull request provides support in ui5-middleware-simpleproxy for specifying the `baseUri` and `strictSSL` configuration via environment variable or `.env` file. This addresses issue #174 for this package.

Also:
- Removes repetitive existence-checked access of `options.configuration`
- Adds a existence check on access of `options.configuration.debug` that is now required because it is possible to run without a configuration section