### PR TITLE
package.json: Ignore all non-ui5 dependencies

### DIFF
--- a/packages/ui5-middleware-cfdestination/package.json
+++ b/packages/ui5-middleware-cfdestination/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-middleware-iasync/package.json
+++ b/packages/ui5-middleware-iasync/package.json
@@ -18,5 +18,8 @@
     },
     "devDependencies": {
         "npm-check-updates": "^4.1.1"
+    },
+    "ui5": {
+        "dependencies": []
     }
 }

--- a/packages/ui5-middleware-index/package.json
+++ b/packages/ui5-middleware-index/package.json
@@ -10,5 +10,8 @@
   },
   "dependencies": {
     "@ui5/logger": "^1.0.2"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-middleware-livereload/package.json
+++ b/packages/ui5-middleware-livereload/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-middleware-livetranspile/package.json
+++ b/packages/ui5-middleware-livetranspile/package.json
@@ -19,5 +19,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-middleware-servestatic/package.json
+++ b/packages/ui5-middleware-servestatic/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-middleware-simpleproxy/package.json
+++ b/packages/ui5-middleware-simpleproxy/package.json
@@ -17,5 +17,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-task-transpile/package.json
+++ b/packages/ui5-task-transpile/package.json
@@ -20,5 +20,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }

--- a/packages/ui5-task-zipper/package.json
+++ b/packages/ui5-task-zipper/package.json
@@ -18,5 +18,8 @@
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"
+  },
+  "ui5": {
+    "dependencies": []
   }
 }


### PR DESCRIPTION
Enable UI5 Tooling to skip analysis of irrelevant packages. This speeds
up dependency processing and reduces the likelyhood of "JavaScript heap
out of memory" issues.