### PR TITLE
Ignore local routes

### DIFF
--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -31,8 +31,9 @@ module.exports = function ({ resources, options }) {
     xsappConfig.authenticationMethod = "none";
 
     let regExes = [];
-    xsappConfig.routes.forEach(route => {
+    xsappConfig.routes = xsappConfig.routes.filter((route) => !route.localDir); //ignore local routes as they are already hosted by the ui5 tooling
 
+    xsappConfig.routes.forEach(route => {
         route.authenticationType = "none";
         // ignore /-redirects (e.g. "^/(.*)"
         // a source declaration such as "^/backend/(.*)$" is needed


### PR DESCRIPTION
Local routes break the middleware because the "webapp" folder doesn't exist.
The webapp is already served by the UI5 tooling itself, so this route isn't needed anylonger. 