### PR TITLE
Automatically set a non-taken port for livereload server

### DIFF
--- a/packages/ui5-middleware-livereload/README.md
+++ b/packages/ui5-middleware-livereload/README.md
@@ -14,7 +14,7 @@ npm install ui5-middleware-livereload --save-dev
   verbose logging
 - ext: `string`, default: "xml,json,properties"  
   file extensions other than `js`, `html` and `css` to monitor for changes
-- port: `integer`, default: 35729  
+- port: `integer`, default: an open port choosen from _35729_  
   port the live reload server is started on
 - watchPath|path: `string`, default: `webapp`  
   path inside `$yourapp` the reload server monitors for changes

--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -2,6 +2,26 @@ const connectLivereload = require("connect-livereload");
 const livereload = require("livereload");
 const path = require("path");
 const log = require("@ui5/logger").getLogger("server:custommiddleware:livereload");
+const portfinder = require("portfinder"); 
+
+/**
+ * Parses the configuration option. If the port passed then it returns with it.
+ * If not passed it returns with the following free port after the deafult port.
+ * @param {Object} options the entered config option
+ * @param {number} defaultPort the port which is defaulted
+ * @returns {number}
+ */
+const getPortForLivereload = async (options, defaultPort) => {
+    if (options.configuration && options.configuration.port) {
+        return options.configuration.port;
+    }
+    try {
+        portfinder.basePort = defaultPort;
+        return await portfinder.getPortPromise();
+    } catch {
+        return defaultPort;
+    }
+}
 
 /**
  * Custom UI5 Server middleware example
@@ -18,8 +38,8 @@ const log = require("@ui5/logger").getLogger("server:custommiddleware:livereload
  * @param {string} [parameters.options.configuration] Custom server middleware configuration if given in ui5.yaml
  * @returns {function} Middleware function to use
  */
-module.exports = ({ resources, options }) => {
-    let port = 35729;
+module.exports = async ({ resources, options }) => {
+    let port = await getPortForLivereload(options, 35729);
     if (options.configuration && options.configuration.port) {
         port = options.configuration.port;
     }

--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -40,9 +40,6 @@ const getPortForLivereload = async (options, defaultPort) => {
  */
 module.exports = async ({ resources, options }) => {
     let port = await getPortForLivereload(options, 35729);
-    if (options.configuration && options.configuration.port) {
-        port = options.configuration.port;
-    }
     let watchPath = "webapp";
     // due to compatibility reasons we keep the path as watchPath (watchPath has higher precedence than path)
     if (options.configuration && (options.configuration.watchPath || options.configuration.path)) {

--- a/packages/ui5-middleware-livereload/package.json
+++ b/packages/ui5-middleware-livereload/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "@ui5/logger": "^1.0.2",
     "connect-livereload": "^0.6.1",
-    "livereload": "^0.9.1"
+    "livereload": "^0.9.1",
+    "portfinder": "^1.0.26"
   },
   "devDependencies": {
     "npm-check-updates": "^4.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3709,7 +3709,7 @@ debug@4, debug@4.1.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
   dependencies:
     ms "^2.1.1"
 
-debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.2.6:
+debug@^3.0.0, debug@^3.0.1, debug@^3.1.0, debug@^3.1.1, debug@^3.2.6:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -6967,10 +6967,15 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@~0.0.1:
+minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass-collect@^1.0.2:
   version "1.0.2"
@@ -8162,6 +8167,15 @@ pkg-up@^3.1.0:
   integrity sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==
   dependencies:
     find-up "^3.0.0"
+
+portfinder@^1.0.26:
+  version "1.0.26"
+  resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.26.tgz#475658d56ca30bed72ac7f1378ed350bd1b64e70"
+  integrity sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==
+  dependencies:
+    async "^2.6.2"
+    debug "^3.1.1"
+    mkdirp "^0.5.1"
 
 portscanner@2.1.1:
   version "2.1.1"


### PR DESCRIPTION
Setting automatically an open port in case the `option.configuration.port` is not supplied. The free port selection is made by [portfinder](https://www.npmjs.com/package/portfinder), it scans the ports from _35729_ toward _65535_.