### PR TITLE
feat: new custom task - stringsreplacer

### DIFF
--- a/packages/ui5-app/.env
+++ b/packages/ui5-app/.env
@@ -1,0 +1,2 @@
+stringreplacer.BASE_URL_PLACEHOLDER = http://localhost:2000
+stringreplacer.ANOTHER_PLACEHOLDER = Replace with this text

--- a/packages/ui5-app/.env
+++ b/packages/ui5-app/.env
@@ -1,2 +1,2 @@
 stringreplacer.BASE_URL_PLACEHOLDER = http://localhost:2000
-stringreplacer.some.deeply.nested.ANOTHER_PLACEHOLDER = Replace with this text
+STRINGREPLACER.some.deeply.nested.ANOTHER_PLACEHOLDER = Replace with this text

--- a/packages/ui5-app/.env
+++ b/packages/ui5-app/.env
@@ -1,2 +1,2 @@
 stringreplacer.BASE_URL_PLACEHOLDER = http://localhost:2000
-stringreplacer.ANOTHER_PLACEHOLDER = Replace with this text
+stringreplacer.some.deeply.nested.ANOTHER_PLACEHOLDER = Replace with this text

--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -52,7 +52,7 @@
     "ui5-middleware-simpleproxy": "^0.2.3",
     "ui5-task-i18ncheck": "^0.2.1",
     "ui5-task-pwa-enabler": "^0.1.0",
-    "ui5-task-stringreplacer": "^0.1.0",
+    "ui5-task-stringreplacer": "^0.3.0",
     "ui5-task-transpile": "^0.1.7",
     "ui5-task-zipper": "^0.2.0"
   },

--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -52,6 +52,7 @@
     "ui5-middleware-simpleproxy": "^0.2.3",
     "ui5-task-i18ncheck": "^0.2.1",
     "ui5-task-pwa-enabler": "^0.1.0",
+    "ui5-task-stringreplacer": "^0.1.0",
     "ui5-task-transpile": "^0.1.7",
     "ui5-task-zipper": "^0.2.0"
   },
@@ -67,7 +68,8 @@
       "ui5-task-i18ncheck",
       "ui5-task-pwa-enabler",
       "ui5-task-transpile",
-      "ui5-task-zipper"
+      "ui5-task-zipper",
+      "ui5-task-stringreplacer"
     ]
   }
 }

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -18,7 +18,15 @@ builder:
       debug: true
       removeConsoleStatements: true
       excludePatterns:
-      - "lib/"
+        - "lib/"
+  - name: ui5-task-stringreplacer
+    afterTask: replaceVersion
+    configuration:
+      files: ["**/*.js", "**/*.xml"]
+      strings:
+        [
+          { placeholder: $PLACEHOLDER1$, value: localhost:2000 }
+        ]
   - name: ui5-task-i18ncheck
     afterTask: replaceVersion
   - name: ui5-task-zipper

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -19,14 +19,14 @@ builder:
       removeConsoleStatements: true
       excludePatterns:
         - "lib/"
-    - name: ui5-task-stringreplacer
-      afterTask: replaceVersion
-      configuration:
-        files: ["**/*.js", "**/*.xml"]
-        strings:
-          [
-            { placeholder: $PLACEHOLDER1$, value: localhost:2000 }
-          ]
+  - name: ui5-task-stringreplacer
+    afterTask: replaceVersion
+    configuration:
+      files: ["**/*.js", "**/*.xml"]
+      strings:
+        [
+          { placeholder: $PLACEHOLDER1$, value: localhost:2000 }
+        ]
   - name: ui5-task-i18ncheck
     afterTask: replaceVersion
   - name: ui5-task-zipper

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -23,10 +23,6 @@ builder:
     afterTask: replaceVersion
     configuration:
       files: ["**/*.js", "**/*.xml"]
-      strings:
-        [
-          { placeholder: $PLACEHOLDER1$, value: localhost:2000 }
-        ]
   - name: ui5-task-i18ncheck
     afterTask: replaceVersion
   - name: ui5-task-zipper

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -19,14 +19,14 @@ builder:
       removeConsoleStatements: true
       excludePatterns:
         - "lib/"
-  - name: ui5-task-stringreplacer
-    afterTask: replaceVersion
-    configuration:
-      files: ["**/*.js", "**/*.xml"]
-      strings:
-        [
-          { placeholder: $PLACEHOLDER1$, value: localhost:2000 }
-        ]
+    - name: ui5-task-stringreplacer
+      afterTask: replaceVersion
+      configuration:
+        files: ["**/*.js", "**/*.xml"]
+        strings:
+          [
+            { placeholder: $PLACEHOLDER1$, value: localhost:2000 }
+          ]
   - name: ui5-task-i18ncheck
     afterTask: replaceVersion
   - name: ui5-task-zipper

--- a/packages/ui5-app/webapp/controller/App.controller.js
+++ b/packages/ui5-app/webapp/controller/App.controller.js
@@ -6,6 +6,10 @@ sap.ui.define([
 	return Controller.extend("test.Sample.controller.App", {
 		onInit() {
 			console.log("Statement will be removed if transpile task is configured accordingly.")
+
+			// Build file will have baseUrl as localhost:2000
+			// replaced from ui5.yaml file with UI5 task ui5-task-stringreplacer
+			var baseUrl = "$PLACEHOLDER1$";
 		}
 	});
 });

--- a/packages/ui5-app/webapp/controller/App.controller.js
+++ b/packages/ui5-app/webapp/controller/App.controller.js
@@ -9,7 +9,8 @@ sap.ui.define([
 
 			// Build file will have baseUrl as localhost:2000
 			// replaced from ui5.yaml file with UI5 task ui5-task-stringreplacer
-			var baseUrl = "$PLACEHOLDER1$";
+			var baseUrl = "BASE_URL_PLACEHOLDER";
+			var randomTextToReplace = "ANOTHER_PLACEHOLDER";
 		}
 	});
 });

--- a/packages/ui5-app/webapp/controller/App.controller.js
+++ b/packages/ui5-app/webapp/controller/App.controller.js
@@ -10,7 +10,7 @@ sap.ui.define([
 			// Build file will have baseUrl as localhost:2000
 			// replaced from ui5.yaml file with UI5 task ui5-task-stringreplacer
 			var baseUrl = "BASE_URL_PLACEHOLDER";
-			var randomTextToReplace = "ANOTHER_PLACEHOLDER";
+			var randomTextToReplace = "some.deeply.nested.ANOTHER_PLACEHOLDER";
 		}
 	});
 });

--- a/packages/ui5-task-stringreplacer/CHANGELOG.md
+++ b/packages/ui5-task-stringreplacer/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.

--- a/packages/ui5-task-stringreplacer/README.md
+++ b/packages/ui5-task-stringreplacer/README.md
@@ -51,14 +51,14 @@ builder:
       configuration:
         files: ["**/*.js", "**/*.xml"]
 ```
-3. Maintain all string placeholders and values in .env file
+3. Maintain all string placeholders and values in `.env` file
 ```env
 stringreplacer.BASE_URL_PLACEHOLDER = http://localhost:2000
-stringreplacer.ANOTHER_PLACEHOLDER = Replace with this text
+stringreplacer.some.deeply.nested.ANOTHER_PLACEHOLDER = Replace with this text
 ```
 ## How it works
 
-The task reads all files based on configuration patterns and replaces all string placeholders with values for all files. All the string placeholders which are maintained in .env with prefix 'stringreplacer.' will be taken into account.
+The task reads all files based on configuration patterns and replaces all string placeholders with values for all files. All the string placeholders which are maintained in `.env` with prefix 'stringreplacer.' will be taken into account.
 
 ## License
 

--- a/packages/ui5-task-stringreplacer/README.md
+++ b/packages/ui5-task-stringreplacer/README.md
@@ -18,11 +18,6 @@ yarn install --dev ui5-task-stringreplacer
 
 ```bash
 files: ["**/*.js", "**/*.xml"]
-strings:
-    [
-        { placeholder: $PLACEHOLDER1$, value: Actual Value 1 },
-        { placeholder: $PLACEHOLDER2$, value: Actual Value 2 },
-    ]
 ```
 
 ## Usage
@@ -55,16 +50,15 @@ builder:
       afterTask: replaceVersion
       configuration:
         files: ["**/*.js", "**/*.xml"]
-        strings:
-          [
-            { placeholder: $PLACEHOLDER1$, value: Actual Value 1 },
-            { placeholder: $PLACEHOLDER2$, value: Actual Value 2 },
-          ]
 ```
-
+3. Maintain all string placeholders and values in .env file
+```env
+stringreplacer.BASE_URL_PLACEHOLDER = http://localhost:2000
+stringreplacer.ANOTHER_PLACEHOLDER = Replace with this text
+```
 ## How it works
 
-The task reads all files based on configuration patterns and replaces all placeholders with values for all files.
+The task reads all files based on configuration patterns and replaces all string placeholders with values for all files. All the string placeholders which are maintained in .env with prefix 'stringreplacer.' will be taken into account.
 
 ## License
 

--- a/packages/ui5-task-stringreplacer/README.md
+++ b/packages/ui5-task-stringreplacer/README.md
@@ -1,0 +1,73 @@
+# UI5 task for replacing strings from any files while creating build
+
+Task for [ui5-builder](https://github.com/SAP/ui5-builder), replacing string values.
+
+## Install
+
+```bash
+npm install ui5-task-stringreplacer --save-dev
+```
+
+or
+
+```bash
+yarn install --dev ui5-task-stringreplacer
+```
+
+## Configuration options (in `$yourapp/ui5.yaml`)
+
+```bash
+files: ["**/*.js", "**/*.xml"]
+strings:
+    [
+        { placeholder: $PLACEHOLDER1$, value: Actual Value 1 },
+        { placeholder: $PLACEHOLDER2$, value: Actual Value 2 },
+    ]
+```
+
+## Usage
+
+1. Define the dependency in `$yourapp/package.json`:
+
+```json
+"devDependencies": {
+    // ...
+    "ui5-task-stringreplacer": "*"
+    // ...
+},
+"ui5": {
+  "dependencies": [
+    // ...
+    "ui5-task-stringreplacer",
+    // ...
+  ]
+}
+```
+
+> As the devDependencies are not recognized by the UI5 tooling, they need to be listed in the `ui5 > dependencies` array. In addition, once using the `ui5 > dependencies` array you need to list all UI5 tooling relevant dependencies.
+
+2. configure it in `$yourapp/ui5.yaml`:
+
+```yaml
+builder:
+  customTasks:
+    - name: ui5-task-stringreplacer
+      afterTask: replaceVersion
+      configuration:
+        files: ["**/*.js", "**/*.xml"]
+        strings:
+          [
+            { placeholder: $PLACEHOLDER1$, value: Actual Value 1 },
+            { placeholder: $PLACEHOLDER2$, value: Actual Value 2 },
+          ]
+```
+
+## How it works
+
+The task reads all files based on configuration patterns and replaces all placeholders with values for all files.
+
+## License
+
+This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally, you can choose between one of them if you use this work.
+
+When you like this stuff, buy [@vobu](https://twitter.com/vobu) a beer or buy [@pmuessig](https://twitter.com/pmuessig) or [@TheVivekGowda](https://twitter.com/TheVivekGowda) a coke when you see them.

--- a/packages/ui5-task-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-task-stringreplacer/lib/stringreplacer.js
@@ -1,7 +1,33 @@
 const replaceStream = require("replacestream");
+const dotenv = require("dotenv");
 const log = require("@ui5/logger").getLogger(
   "builder:customtask:stringreplacer"
 );
+
+dotenv.config();
+
+// get all environment variables
+const envVariables = process.env;
+let placeholderStrings = [];
+
+// loop through env variables to find keys which are having prefix 'stringreplacer'
+if (typeof envVariables === "object") {
+  for (key in envVariables) {
+    // env variable should start with 'stringreplacer' and should in format 'stringreplacer.placeholder'
+    if (key.startsWith("stringreplacer")) {
+      if (!key.split(".")[1]) {
+        log.error(
+          "Failed to replace strings. Expected format is stringreplacer.placeholder=value"
+        );
+      }
+      let placeholderString = key.split(".")[1];
+      placeholderStrings.push({
+        placeholder: placeholderString,
+        value: envVariables[key],
+      });
+    }
+  }
+}
 
 /**
  * Task to replace strings from files
@@ -21,7 +47,7 @@ module.exports = function ({ workspace, options }) {
       // replaces all files placeholder strings with replacement text values
       return replaceStrings({
         resources: allResources,
-        strings: options.configuration.strings,
+        strings: placeholderStrings,
       });
     })
     .then((processedResources) => {

--- a/packages/ui5-task-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-task-stringreplacer/lib/stringreplacer.js
@@ -15,7 +15,7 @@ if (typeof envVariables === "object") {
   for (key in envVariables) {
     // env variable should start with 'stringreplacer' and should in format 'stringreplacer.placeholder'
     if (/^stringreplacer\.(.+)$/i.test(key)) {
-      let placeholderString = key.split(".")[key.split(".").length - 1];
+      let placeholderString = /^stringreplacer\.(.+)$/i.exec(key)[1];
       placeholderStrings.push({
         placeholder: placeholderString,
         value: envVariables[key],

--- a/packages/ui5-task-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-task-stringreplacer/lib/stringreplacer.js
@@ -20,7 +20,7 @@ if (typeof envVariables === "object") {
           "Failed to replace strings. Expected format is stringreplacer.placeholder=value"
         );
       }
-      let placeholderString = key.split(".")[1];
+      let placeholderString = key.split(".")[key.split(".").length - 1];
       placeholderStrings.push({
         placeholder: placeholderString,
         value: envVariables[key],
@@ -56,6 +56,11 @@ module.exports = function ({ workspace, options }) {
           return workspace.write(resource);
         })
       );
+    })
+    .catch((err) => {
+      log.error(
+        "Failed to replace strings. Please check file patterns and string placeholders."
+      );
     });
 };
 /**
@@ -64,17 +69,15 @@ module.exports = function ({ workspace, options }) {
  * @param {Array} parameters.strings Array of objects containing placeholder and replacment text value
  */
 replaceStrings = function ({ resources, strings }) {
-  return Promise.all(
-    resources.map((resource) => {
-      let stream = resource.getStream();
-      stream.setEncoding("utf8");
+  return resources.map((resource) => {
+    let stream = resource.getStream();
+    stream.setEncoding("utf8");
 
-      strings.forEach((string) => {
-        stream = stream.pipe(replaceStream(string.placeholder, string.value));
-      });
+    strings.forEach((string) => {
+      stream = stream.pipe(replaceStream(string.placeholder, string.value));
+    });
 
-      resource.setStream(stream);
-      return resource;
-    })
-  );
+    resource.setStream(stream);
+    return resource;
+  });
 };

--- a/packages/ui5-task-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-task-stringreplacer/lib/stringreplacer.js
@@ -14,12 +14,7 @@ let placeholderStrings = [];
 if (typeof envVariables === "object") {
   for (key in envVariables) {
     // env variable should start with 'stringreplacer' and should in format 'stringreplacer.placeholder'
-    if (key.startsWith("stringreplacer")) {
-      if (!key.split(".")[1]) {
-        log.error(
-          "Failed to replace strings. Expected format is stringreplacer.placeholder=value"
-        );
-      }
+    if (/^stringreplacer\.(.+)$/i.test(key)) {
       let placeholderString = key.split(".")[key.split(".").length - 1];
       placeholderStrings.push({
         placeholder: placeholderString,

--- a/packages/ui5-task-stringreplacer/lib/stringreplacer.js
+++ b/packages/ui5-task-stringreplacer/lib/stringreplacer.js
@@ -1,0 +1,54 @@
+const replaceStream = require("replacestream");
+const log = require("@ui5/logger").getLogger(
+  "builder:customtask:stringreplacer"
+);
+
+/**
+ * Task to replace strings from files
+ *
+ * @param {Object} parameters Parameters
+ * @param {DuplexCollection} parameters.workspace DuplexCollection to read and write files
+ * @param {AbstractReader} parameters.dependencies Reader or Collection to read dependency files
+ * @param {Object} parameters.options Options
+ * @param {Array} parameters.options.files all file name patterns where replace should occur
+ * @param {Array} [parameters.options.strings] Array of objects containing placeholder and replacment text value
+ * @returns {Promise<undefined>} Promise resolving with undefined once data has been written
+ */
+module.exports = function ({ workspace, options }) {
+  return workspace
+    .byGlob(options.configuration.files)
+    .then((allResources) => {
+      // replaces all files placeholder strings with replacement text values
+      return replaceStrings({
+        resources: allResources,
+        strings: options.configuration.strings,
+      });
+    })
+    .then((processedResources) => {
+      return Promise.all(
+        processedResources.map((resource) => {
+          return workspace.write(resource);
+        })
+      );
+    });
+};
+/**
+ * @param {Object} parameters Parameters
+ * @param {Array} parameters.resources files
+ * @param {Array} parameters.strings Array of objects containing placeholder and replacment text value
+ */
+replaceStrings = function ({ resources, strings }) {
+  return Promise.all(
+    resources.map((resource) => {
+      let stream = resource.getStream();
+      stream.setEncoding("utf8");
+
+      strings.forEach((string) => {
+        stream = stream.pipe(replaceStream(string.placeholder, string.value));
+      });
+
+      resource.setStream(stream);
+      return resource;
+    })
+  );
+};

--- a/packages/ui5-task-stringreplacer/package.json
+++ b/packages/ui5-task-stringreplacer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ui5-task-stringreplacer",
-    "version": "0.1.0",
+    "version": "0.3.0",
     "description": "Task for the UI5 tooling to replace string placeholders.",
     "author": "TheVivekGowda",
     "license": "Apache-2.0",

--- a/packages/ui5-task-stringreplacer/package.json
+++ b/packages/ui5-task-stringreplacer/package.json
@@ -10,6 +10,7 @@
     },
     "scripts": {},
     "dependencies": {
+        "dotenv": "^8.2.0",
         "replacestream": "^4.0.3"
     },
     "devDependencies": {},

--- a/packages/ui5-task-stringreplacer/package.json
+++ b/packages/ui5-task-stringreplacer/package.json
@@ -1,0 +1,19 @@
+{
+    "name": "ui5-task-stringreplacer",
+    "version": "0.1.0",
+    "description": "Task for the UI5 tooling to replace string placeholders.",
+    "author": "TheVivekGowda",
+    "license": "Apache-2.0",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/petermuessig/ui5-ecosystem-showcase.git"
+    },
+    "scripts": {},
+    "dependencies": {
+        "replacestream": "^4.0.3"
+    },
+    "devDependencies": {},
+    "ui5": {
+        "dependencies": []
+    }
+}

--- a/packages/ui5-task-stringreplacer/ui5.yaml
+++ b/packages/ui5-task-stringreplacer/ui5.yaml
@@ -1,0 +1,8 @@
+# https://sap.github.io/ui5-tooling/pages/extensibility/CustomTasks/
+specVersion: "1.0"
+metadata:
+  name: ui5-task-stringreplacer
+kind: extension
+type: task
+task:
+  path: lib/stringreplacer.js


### PR DESCRIPTION
Hello @petermuessig  and @vobu ,

In one of my project we had below requirements

- Replacing API URLs based on different deployment environment.
- We had few applications links which can be opened from our UI5 application. These links were pointing to different URLs in each deployment environment.
- Also we wanted to manage copyright text and other few dynamic texts based on different builds.

So earlier we were using grunt-replace for all these requirement. Since we are migrating our applications to UI5 tools now, thought of creating a custom UI5 task which will fix all our requirements.

Screenshots from sample code:
Source code:

![image](https://user-images.githubusercontent.com/19553091/82729030-dc0bff00-9d11-11ea-998a-16a314f90e7e.png)

Managing string placeholders in .yaml

![image](https://user-images.githubusercontent.com/19553091/82729050-ff36ae80-9d11-11ea-9b08-443e0f34ec73.png)

dbg file inside dist

![image](https://user-images.githubusercontent.com/19553091/82729062-0fe72480-9d12-11ea-8d6e-5de060c005fa.png)

Currently I am handling different environment deployments using multiple .yaml files. But it can be improved using .env file too.

UI5 task is published in NPM: https://www.npmjs.com/package/ui5-task-stringreplacer

I am open for your suggestions on improving this custom task.

Thanks,
Vivek