### PR TITLE
Keeps cookie structure after removing secure flag while proxying

### DIFF
--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -95,7 +95,7 @@ module.exports = function ({ resources, options }) {
             if (Array.isArray(headers[headerName])) {
               headers[headerName] = headers[headerName].map(function(cookieValue) {
                 console.log(cookieValue);
-                return cookieValue.replace(/;\s*secure\s*(?:;|$)/g, "");
+                return cookieValue.replace(/;\s*secure\s*(?:;|$)/gi, ";");
               });
             }
           }

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -94,14 +94,23 @@ module.exports = function ({ resources, options }) {
             // remove the secure flag of the cookies
             if (Array.isArray(headers[headerName])) {
               headers[headerName] = headers[headerName]
+                // remove flag 'Secure'
                 .map(function(cookieValue) {
                   return cookieValue.replace(/;\s*secure\s*(?:;|$)/gi, ";");
                 })
+                // remove attribute 'Domain'
                 .map(function (cookieValue) {
                   return cookieValue.replace(/;\s*domain=[^;]+\s*(?:;|$)/gi, ";");
                 })
+                // remove attribute 'Path'
                 .map(function (cookieValue) {
                   return cookieValue.replace(/;\s*path=[^;]+\s*(?:;|$)/gi, ";");
+                })
+                // remove attribute 'SameSite'
+                .map(function (cookieValue) {
+                  return cookieValue.replace(/;\s*samesite=[^;]+\s*(?:;|$)/gi, ";");
+                  // alternatively replace the value with 'Lax':
+                  // return cookieValue.replace(/;\s*samesite=[^;]+\s*(?:;|$)/gi, "; SameSite=Lax;");
                 });
             }
           }

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -93,10 +93,16 @@ module.exports = function ({ resources, options }) {
           if (/set-cookie/i.test(headerName)) {
             // remove the secure flag of the cookies
             if (Array.isArray(headers[headerName])) {
-              headers[headerName] = headers[headerName].map(function(cookieValue) {
-                console.log(cookieValue);
-                return cookieValue.replace(/;\s*secure\s*(?:;|$)/gi, ";");
-              });
+              headers[headerName] = headers[headerName]
+                .map(function(cookieValue) {
+                  return cookieValue.replace(/;\s*secure\s*(?:;|$)/gi, ";");
+                })
+                .map(function (cookieValue) {
+                  return cookieValue.replace(/;\s*domain=[^;]+\s*(?:;|$)/gi, ";");
+                })
+                .map(function (cookieValue) {
+                  return cookieValue.replace(/;\s*path=[^;]+\s*(?:;|$)/gi, ";");
+                });
             }
           }
         });


### PR DESCRIPTION
When removing the secure flag from the cookie one semicolon must remain.
Otherwise cookie attributes might be merged into values, leading to invalid cookies.
Before this change both semicolons before and after the secure flag were removed.
This change makes sure one of them remains.

Fixes: #236