### PR TITLE
fix: default to debug false

### DIFF
--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -49,7 +49,7 @@ module.exports = async ({ resources, options }) => {
     if (options.configuration && options.configuration.extraExts) {
         extraExts = options.configuration.extraExts;
     }
-    let debug = true;
+    let debug = false;
     if (options.configuration && options.configuration.debug) {
         debug = options.configuration.debug;
     }


### PR DESCRIPTION
Today I updated the livereload middleware for my project and the livereload-server was logging verbosely although I disabled that via configuration.
It took some debugging for me to detect the issue. 
`if (options.configuration && options.configuration.debug) {` is only true if debug is configured as true. This causes that the configured `false` will never be written in let debug. Simple workaround for that is defaulting the debug variable to false (I anyway don´t see the point for enabling it).