### PR TITLE
Add documentation for extended babel configuration

### DIFF
--- a/packages/ui5-middleware-livetranspile/README.md
+++ b/packages/ui5-middleware-livetranspile/README.md
@@ -59,7 +59,11 @@ The middleware intercepts every `.js`-file before it is sent to the client. The 
 
 The transpiled code and the `sourcemap` are subsequently delivered to the client instead of the original `.js`-file. Because of the `sourcemap`, setting breakpoints in the **original (ES6+) source** will cause the debugger to stop **when the corresponding transpiled source code is reached**.
 
-> `async/await` is transpiled at runtime, but the required `asyncGenerator` sources are not yet delivered on the fly. They need to be `sap.ui.require`d or `<script src="...">`d separately.  
+> `async/await` is transpiled at runtime, but the required `asyncGenerator` sources are not yet delivered on the fly. They need to be `sap.ui.require`d or `<script src="...">`d separately. Alternatively you can use the babel plugin `babel-plugin-transform-async-to-promises` as described [here](../ui5-task-transpile/README.md).
+
+## Extended configuration (in `$yourapp/babel.config.json`)
+
+If you want to further customize the transpiling options you can do so by creating a babel config file `babel.config.json` in your project directory. The behavior is identical to that of `ui5-task-transpile`. For more details and examples consult the [documentation of `ui5-task-transpile`](../ui5-task-transpile/README.md).
 
 ## Misc/FAQ
 

--- a/packages/ui5-task-transpile/README.md
+++ b/packages/ui5-task-transpile/README.md
@@ -61,6 +61,41 @@ builder:
 
 The task can be used to transpile ES6+ JavaScript code to ES5 by using `babel`.
 
+## Extended configuration (in `$yourapp/babel.config.json`)
+
+If you want to further customize the transpiling options you can do so by creating a babel config file `babel.config.json` in your project directory. Babel will automatically pick up the configuration and apply it. The default configuration from this task will still be applied.
+
+### Example
+
+An example configuration is as follows:
+
+```json
+{
+  "plugins": [
+    ["@babel/plugin-transform-for-of", { "assumeArray": true }],
+    ["@babel/plugin-transform-computed-properties", { "loose": true }],
+    ["@babel/plugin-transform-destructuring", { "loose": true }]
+  ]
+}
+```
+
+### Additional dependencies
+
+If you need dependencies not included in this task you have to install them in your project in order to use them.
+
+For example, in order to transpile `async`/`await` to `Promise`s you can install
+`babel-plugin-transform-async-to-promises` as development dependency to your project and add it to the babel configuration's `plugins` section:
+
+```json
+{
+  "plugins": [
+    // ...
+    ["babel-plugin-transform-async-to-promises", { "inlineHelpers": true }]
+    // ...
+  ]
+}
+```
+
 ## License
 
 This work is [dual-licensed](../../LICENSE) under Apache 2.0 and the Derived Beer-ware License. The official license will be Apache 2.0 but finally you can choose between one of them if you use this work.


### PR DESCRIPTION
I added documentation to `ui5-task-transpile` and `ui5-middleware-livetranspile` that describes how to add more configuration options to babel. The configuration for both packages is identical and I added the detailed documentation to `ui5-task-transpile` only. The `ui5-middleware-livetranspile` references to that documentation.

Closes: #246 