### PR TITLE
Enable overriding babel configuration

### DIFF
--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "@openui5/ts-types": "^1.60.5",
     "@ui5/cli": "^2.2.4",
+    "babel-plugin-transform-async-to-promises": "^0.8.15",
     "karma": "^5.0.9",
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",

--- a/packages/ui5-app/ui5-custom-babel.yaml
+++ b/packages/ui5-app/ui5-custom-babel.yaml
@@ -1,0 +1,105 @@
+specVersion: "2.0"
+metadata:
+  name: ui5-app
+type: application
+framework:
+  name: OpenUI5
+  version: "1.77.1"
+  libraries:
+    - name: sap.m
+    - name: sap.ui.core
+    - name: sap.ui.layout
+    - name: themelib_sap_fiori_3
+builder:
+  customTasks:
+  - name: ui5-task-transpile
+    afterTask: replaceVersion
+    configuration:
+      debug: true
+      excludePatterns:
+        - "lib/"
+      babelConfig: &babelConfig
+        plugins:
+          -
+            - "@babel/plugin-transform-computed-properties"
+            - loose: true
+          -
+            - "@babel/plugin-transform-for-of"
+            - assumeArray: true
+          -
+            - "babel-plugin-transform-async-to-promises"
+            - inlineHelpers: true
+        presets:
+          - 
+            - "@babel/preset-env"
+            - targets:
+                browsers: "last 2 versions, ie 10-11"
+  - name: ui5-task-stringreplacer
+    afterTask: replaceVersion
+    configuration:
+      files: ["**/*.js", "**/*.xml"]
+  - name: ui5-task-i18ncheck
+    afterTask: replaceVersion
+  - name: ui5-task-zipper
+    afterTask: uglify 
+    configuration:
+      archiveName: "webapp"
+      additionalFiles:
+      - "xs-app.json"
+# https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/
+server:
+  customMiddleware:
+  - name: ui5-middleware-livereload
+    afterMiddleware: compression
+    configuration:
+      debug: true
+      extraExts: "xml,json,properties"
+      path: "webapp"
+  - name: ui5-middleware-simpleproxy
+    mountPath: /proxy
+    afterMiddleware: compression
+    configuration:
+      debug: true
+      baseUri: "https://latest-openui5.rikosjett.com"
+      httpHeaders:
+        Any-Header: AnyHeader
+    # PoC: reuse the same middleware at a different "mountPath"
+  - name: ui5-middleware-simpleproxy
+    mountPath: /proxy2
+    afterMiddleware: compression
+    configuration:
+      baseUri: "https://latest-openui5.rikosjett.com"
+  - name: ui5-middleware-livetranspile
+    afterMiddleware: compression
+    configuration:
+      debug: true
+      excludePatterns:
+      - "lib/"
+      babelConfig:
+        <<: *babelConfig
+        sourceMaps: "inline"
+  - name: ui5-middleware-cfdestination
+    afterMiddleware: compression
+    configuration:
+      debug: true
+      port: 1091
+      xsappJson: "xs-app.json"
+      destinations:
+      # check that the destination name (here: "backend") matches your router in xssppJson
+      - name: "backend"
+        url: "https://services.odata.org/V4/(S(fdng4tbvlxgzpdtpfap2rqss))/TripPinServiceRW/"
+      - name: "odatav2"
+        url: "https://services.odata.org/V2/Northwind/Northwind.svc/"
+      - name: "todos"
+        url: "https://jsonplaceholder.typicode.com/todos/"
+  - name: ui5-middleware-iasync
+    beforeMiddleware: serveResources
+    configuration:
+      https: false
+      debug: false
+      logConnections: true
+      port: 4711
+  - name: ui5-middleware-index
+    afterMiddleware: compression
+    configuration:
+      debug: true

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -75,6 +75,7 @@ server:
     afterMiddleware: compression
     configuration:
       debug: true
+      transpileAsync: true
       excludePatterns:
       - "lib/"
       babelConfig:

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -20,22 +20,6 @@ builder:
       transpileAsync: true
       excludePatterns:
         - "lib/"
-      babelConfig: &babelConfig
-        plugins:
-          -
-            - "@babel/plugin-transform-computed-properties"
-            - loose: true
-          -
-            - "@babel/plugin-transform-for-of"
-            - assumeArray: true
-          -
-            - "babel-plugin-transform-async-to-promises"
-            - inlineHelpers: true
-        presets:
-          - 
-            - "@babel/preset-env"
-            - targets:
-                browsers: "last 2 versions, ie 10-11"
   - name: ui5-task-stringreplacer
     afterTask: replaceVersion
     configuration:
@@ -78,9 +62,6 @@ server:
       transpileAsync: true
       excludePatterns:
       - "lib/"
-      babelConfig:
-        <<: *babelConfig
-        sourceMaps: "inline"
   - name: ui5-middleware-cfdestination
     afterMiddleware: compression
     configuration:

--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -19,6 +19,22 @@ builder:
       removeConsoleStatements: true
       excludePatterns:
         - "lib/"
+      babelConfig: &babelConfig
+        plugins:
+          -
+            - "@babel/plugin-transform-computed-properties"
+            - loose: true
+          -
+            - "@babel/plugin-transform-for-of"
+            - assumeArray: true
+          -
+            - "babel-plugin-transform-async-to-promises"
+            - inlineHelpers: true
+        presets:
+          - 
+            - "@babel/preset-env"
+            - targets:
+                browsers: "last 2 versions, ie 10-11"
   - name: ui5-task-stringreplacer
     afterTask: replaceVersion
     configuration:
@@ -57,6 +73,9 @@ server:
       debug: true
       excludePatterns:
       - "lib/"
+      babelConfig:
+        <<: *babelConfig
+        sourceMaps: "inline"
   - name: ui5-middleware-cfdestination
     afterMiddleware: compression
     configuration:

--- a/packages/ui5-app/webapp/includes/iWillBeTranspiled.js
+++ b/packages/ui5-app/webapp/includes/iWillBeTranspiled.js
@@ -1,3 +1,32 @@
 // nothing to see here, just for demo purposes
 
 const [a, ...b] = ["will", "be", "transpiled!"];
+
+const o = {
+  async value() {
+    return 3;
+  },
+
+  async asyncFunction() {
+    const value = await this.value();
+    return value + 1;
+  },
+
+  array() {
+    return [1, 1, 2, 3, 5, 8, 13];
+  },
+
+  iterateDemo() {
+    for (const value of this.array()) {
+      console.log("fibonacci", value);
+    }
+  },
+
+  computedProperty() {
+    const propertyName = "name";
+    const person = {
+      [propertyName]: "John",
+    };
+    return person;
+  },
+};

--- a/packages/ui5-middleware-livetranspile/README.md
+++ b/packages/ui5-middleware-livetranspile/README.md
@@ -17,6 +17,9 @@ verbose logging
 array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
 e.g. 3-rd party libs in `lib/*`
 
+- transpileAsync: `true|false`
+transpiling `async/await` using [this Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises), which doesn't require the regenerator runtime ([Issue #242](https://github.com/petermuessig/ui5-ecosystem-showcase/issues/242))
+
 - babelConfig: `Object`  
 object to use as configuration for babel instead of the default configuration  
 defined in this middleware
@@ -51,6 +54,7 @@ server:
     afterMiddleware: compression
     configuration:
       debug: true
+      transpileAsync: true
       excludePatterns:
       - "lib/"
       - "another/dir/in/webapp"

--- a/packages/ui5-middleware-livetranspile/README.md
+++ b/packages/ui5-middleware-livetranspile/README.md
@@ -17,8 +17,9 @@ verbose logging
 array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
 e.g. 3-rd party libs in `lib/*`
 
-- transpileAsync: `true|false`
-transpiling `async/await` using [this Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises), which doesn't require the regenerator runtime ([Issue #242](https://github.com/petermuessig/ui5-ecosystem-showcase/issues/242))
+- transpileAsync: `true|false`  
+transpiling `async/await`  using [this Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises), which doesn't require  
+the regenerator runtime ([Issue #242](https://github.com/petermuessig/ui5-ecosystem-showcase/issues/242))
 
 - babelConfig: `Object`  
 object to use as configuration for babel instead of the default configuration  
@@ -69,7 +70,7 @@ The transpiled code and the `sourcemap` are subsequently delivered to the client
 
 > `async/await` is transpiled at runtime, but the required `asyncGenerator` sources are not yet delivered on the fly. They need to be `sap.ui.require`d or `<script src="...">`d separately. Alternatively you can use the babel plugin `babel-plugin-transform-async-to-promises` as described [here](../ui5-task-transpile/README.md).
 
-## Extended configuration (in `$yourapp/babel.config.json`)
+## Extending the default configuration (in `$yourapp/babel.config.json`)
 
 If you want to further customize the transpiling options you can do so by creating a babel config file `babel.config.json` in your project directory. The behavior is identical to that of `ui5-task-transpile`. For more details and examples consult the [documentation of `ui5-task-transpile`](../ui5-task-transpile/README.md).
 

--- a/packages/ui5-middleware-livetranspile/README.md
+++ b/packages/ui5-middleware-livetranspile/README.md
@@ -17,6 +17,10 @@ verbose logging
 array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
 e.g. 3-rd party libs in `lib/*`
 
+- babelConfig: `Object`  
+object to use as configuration for babel instead of the default configuration  
+defined in this middleware
+
 ## Usage
 
 1. Define the dependency in `$yourapp/package.json`:
@@ -59,7 +63,11 @@ The middleware intercepts every `.js`-file before it is sent to the client. The 
 
 The transpiled code and the `sourcemap` are subsequently delivered to the client instead of the original `.js`-file. Because of the `sourcemap`, setting breakpoints in the **original (ES6+) source** will cause the debugger to stop **when the corresponding transpiled source code is reached**.
 
-> `async/await` is transpiled at runtime, but the required `asyncGenerator` sources are not yet delivered on the fly. They need to be `sap.ui.require`d or `<script src="...">`d separately.  
+> `async/await` is transpiled at runtime, but the required `asyncGenerator` sources are not yet delivered on the fly. They need to be `sap.ui.require`d or `<script src="...">`d separately. Alternatively you can use the babel plugin `babel-plugin-transform-async-to-promises` as described [here](../ui5-task-transpile/README.md).
+
+## Override babel configuration (in `$yourapp/ui5.yaml`)
+
+You can override the default babel configuration from this package by including an object `babelConfig` in this task's configuration. The behavior is identical to that of `ui5-task-transpile`. For more details and examples consult the [documentation of `ui5-task-transpile`](../ui5-task-transpile/README.md).
 
 ## Misc/FAQ
 

--- a/packages/ui5-middleware-livetranspile/lib/livetranspile.js
+++ b/packages/ui5-middleware-livetranspile/lib/livetranspile.js
@@ -24,12 +24,21 @@ fileNotFoundError.file = ""
  * @returns {function} Middleware function to use
  */
 module.exports = function ({ resources, options }) {
+    const plugins =
+        options.configuration && options.configuration.transpileAsync
+            ? [
+                  "babel-plugin-transform-async-to-promises",
+                  {
+                      inlineHelpers: true
+                  }
+              ]
+            : []
     const babelConfig =
         options.configuration && options.configuration.babelConfig
             ? options.configuration.babelConfig
             : {
                   sourceMaps: "inline",
-                  plugins: [],
+                  plugins,
                   presets: [
                       [
                           "@babel/preset-env",

--- a/packages/ui5-middleware-livetranspile/lib/livetranspile.js
+++ b/packages/ui5-middleware-livetranspile/lib/livetranspile.js
@@ -27,10 +27,12 @@ module.exports = function ({ resources, options }) {
     const plugins =
         options.configuration && options.configuration.transpileAsync
             ? [
-                  "babel-plugin-transform-async-to-promises",
-                  {
-                      inlineHelpers: true
-                  }
+                  [
+                      "babel-plugin-transform-async-to-promises",
+                      {
+                          inlineHelpers: true
+                      }
+                  ]
               ]
             : []
     const babelConfig =

--- a/packages/ui5-middleware-livetranspile/lib/livetranspile.js
+++ b/packages/ui5-middleware-livetranspile/lib/livetranspile.js
@@ -2,6 +2,7 @@ const babel = require("@babel/core")
 const os = require("os")
 const parseurl = require("parseurl")
 const log = require("@ui5/logger").getLogger("server:custommiddleware:livetranspile")
+const merge = require("lodash.merge")
 
 let fileNotFoundError = new Error("file not found!")
 fileNotFoundError.code = 404
@@ -23,6 +24,24 @@ fileNotFoundError.file = ""
  * @returns {function} Middleware function to use
  */
 module.exports = function ({ resources, options }) {
+    const babelConfig =
+        options.configuration && options.configuration.babelConfig
+            ? options.configuration.babelConfig
+            : {
+                  sourceMaps: "inline",
+                  plugins: [],
+                  presets: [
+                      [
+                          "@babel/preset-env",
+                          {
+                              targets: {
+                                  browsers: "last 2 versions, ie 10-11"
+                              }
+                          }
+                      ]
+                  ]
+              }
+
     return (req, res, next) => {
         if (
             req.path &&
@@ -48,20 +67,10 @@ module.exports = function ({ resources, options }) {
                 })
                 .then((source) => {
                     options.configuration && options.configuration.debug ? log.info(`...${pathname} transpiled!`) : null
-                    return babel.transformAsync(source, {
-                        filename: pathname, // necessary for source map <-> source assoc
-                        sourceMaps: "inline",
-                        presets: [
-                            [
-                                "@babel/preset-env",
-                                {
-                                    targets: {
-                                        browsers: "last 2 versions, ie 10-11"
-                                    }
-                                }
-                            ]
-                        ]
+                    const babelConfigForFile = merge({}, babelConfig, {
+                        filename: pathname // necessary for source map <-> source assoc
                     })
+                    return babel.transformAsync(source, babelConfigForFile)
                 })
                 .then((result) => {
                     // send out transpiled source + source map

--- a/packages/ui5-middleware-livetranspile/package.json
+++ b/packages/ui5-middleware-livetranspile/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
     "@ui5/logger": "^1.0.2",
+    "babel-plugin-transform-async-to-promises": "^0.8.15",
     "lodash.merge": "^4.6.2",
     "parseurl": "^1.3.3"
   },

--- a/packages/ui5-middleware-livetranspile/package.json
+++ b/packages/ui5-middleware-livetranspile/package.json
@@ -12,6 +12,7 @@
     "@babel/core": "^7.9.6",
     "@babel/preset-env": "^7.9.6",
     "@ui5/logger": "^1.0.2",
+    "lodash.merge": "^4.6.2",
     "parseurl": "^1.3.3"
   },
   "ui5": {

--- a/packages/ui5-task-transpile/README.md
+++ b/packages/ui5-task-transpile/README.md
@@ -20,12 +20,13 @@ npm install ui5-task-transpile --save-dev
   array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
   e.g. 3-rd party libs in `lib/*`
 
-- transpileAsync: `true|false`
-  transpiling `async/await` using [this Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises), which doesn't require the regenerator runtime ([Issue #242](https://github.com/petermuessig/ui5-ecosystem-showcase/issues/242))
+- transpileAsync: `true|false`  
+  transpiling `async/await` using [this Babel plugin](https://www.npmjs.com/package/babel-plugin-transform-async-to-promises), which doesn't require  
+  the regenerator runtime ([Issue #242](https://github.com/petermuessig/ui5-ecosystem-showcase/issues/242))
 
 - babelConfig: `Object`
-  object to use as configuration for babel instead of the default configuration  
-  defined in this middleware
+  object to use as configuration for babel instead of the  
+  default configuration defined in this middleware
 
 ## Usage
 
@@ -69,7 +70,7 @@ builder:
 
 The task can be used to transpile ES6+ JavaScript code to ES5 by using `babel`.
 
-## Extended configuration (in `$yourapp/babel.config.json`)
+## Extending the default configuration (in `$yourapp/babel.config.json`)
 
 If you want to further customize the transpiling options you can do so by creating a babel config file `babel.config.json` in your project directory. Babel will automatically pick up the configuration and apply it. The default configuration from this task will still be applied.
 
@@ -89,20 +90,7 @@ An example configuration is as follows:
 
 ### Additional dependencies
 
-If you need dependencies not included in this task you have to install them in your project in order to use them.
-
-For example, in order to transpile `async`/`await` to `Promise`s you can install
-`babel-plugin-transform-async-to-promises` as development dependency to your project and add it to the babel configuration's `plugins` section:
-
-```json
-{
-  "plugins": [
-    // ...
-    ["babel-plugin-transform-async-to-promises", { "inlineHelpers": true }]
-    // ...
-  ]
-}
-```
+If you need dependencies not included in this task you have to install them in your project in order to be able to use them.
 
 ## Override babel configuration (in `$yourapp/ui5.yaml`)
 
@@ -146,18 +134,7 @@ builder:
 
 ### Additional dependencies
 
-If you need dependencies not included in this task you have to install them in your project in order to use them.
-
-For example, in order to transpile `async`/`await` to `Promise`s you can install `babel-plugin-transform-async-to-promises` as development dependency to your project and add it to the babel configuration's plugins section:
-
-```yaml
-babelConfig:
-  plugins:
-    # ...
-    - - "babel-plugin-transform-async-to-promises"
-      - inlineHelpers: true
-    # ...
-```
+If you need dependencies not included in this task you have to install them in your project in order to be able to use them.
 
 ## License
 

--- a/packages/ui5-task-transpile/README.md
+++ b/packages/ui5-task-transpile/README.md
@@ -20,9 +20,11 @@ npm install ui5-task-transpile --save-dev
   array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
 array of paths inside `$yourapp/webapp/` to exclude from live transpilation,
   array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
-array of paths inside `$yourapp/webapp/` to exclude from live transpilation,
-  array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
   e.g. 3-rd party libs in `lib/*`
+
+- babelConfig: `Object`
+  object to use as configuration for babel instead of the default configuration  
+  defined in this middleware
 
 ## Usage
 
@@ -64,6 +66,61 @@ builder:
 ## How it works
 
 The task can be used to transpile ES6+ JavaScript code to ES5 by using `babel`.
+
+## Override babel configuration (in `$yourapp/ui5.yaml`)
+
+You can override the default babel configuration from this package by including an object `babelConfig` in this task's configuration. If such an object is given the default configuration from this task will not be considered, but only the configuration given in `ui5.yaml` will be used.
+
+### Example
+
+```yaml
+builder:
+  customTasks:
+    - name: ui5-task-transpile
+      afterTask: replaceVersion
+      configuration:
+        excludePatterns:
+          - "lib/"
+        babelConfig: &babelConfig
+          plugins:
+            - - "@babel/plugin-transform-computed-properties"
+              - loose: true
+            - - "@babel/plugin-transform-for-of"
+              - assumeArray: true
+          presets:
+            - - "@babel/preset-env"
+              - targets:
+                  browsers: "last 2 versions, ie 10-11"
+```
+
+> Hint: if you also use use `ui5-middleware-livetranspile` you probably do not want to duplicate the babel configuration in your `ui5.yaml`. Use YAML anchors in order to reference the babel configuration across the `ui5.yaml` file.
+> In the example above the anchor `&babelConfig` defines the babel configuration of `ui5-task-transpile` and may be re-used in other parts of `ui5.yaml` by using the alias `*babelConfig`:
+>
+> ```yaml
+> server:
+>   customMiddleware:
+>   - name: ui5-middleware-livetranspile
+>     afterMiddleware: compression
+>     configuration:
+>       babelConfig:
+>         <<: *babelConfig
+>         sourceMaps: "inline"
+> ```
+
+### Additional dependencies
+
+If you need dependencies not included in this task you have to install them in your project in order to use them.
+
+For example, in order to transpile `async`/`await` to Promises you can install `babel-plugin-transform-async-to-promises` as development dependency to your project and add it to the babel configuration's plugins section:
+
+```yaml
+babelConfig:
+  plugins:
+    # ...
+    - - "babel-plugin-transform-async-to-promises"
+      - inlineHelpers: true
+    # ...
+```
 
 ## License
 

--- a/packages/ui5-task-transpile/README.md
+++ b/packages/ui5-task-transpile/README.md
@@ -10,15 +10,19 @@ npm install ui5-task-transpile --save-dev
 
 ## Configuration options (in `$yourapp/ui5.yaml`)
 
-- debug: `true|false`
-verbose logging
+- debug: `true|false`  
+  verbose logging
 
-- removeConsoleStatements: `true|false`
-remove console statements while transpiling using [Babel plugin](https://babeljs.io/docs/en/babel-plugin-transform-remove-console)
+- removeConsoleStatements: `true|false`  
+  remove console statements while transpiling using [Babel plugin](https://babeljs.io/docs/en/babel-plugin-transform-remove-console)
 
-- excludePatterns: `String<Array>`
+- excludePatterns: `String<Array>`  
+  array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
 array of paths inside `$yourapp/webapp/` to exclude from live transpilation,
-e.g. 3-rd party libs in `lib/*`
+  array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
+array of paths inside `$yourapp/webapp/` to exclude from live transpilation,
+  array of paths inside `$yourapp/webapp/` to exclude from live transpilation,  
+  e.g. 3-rd party libs in `lib/*`
 
 ## Usage
 

--- a/packages/ui5-task-transpile/lib/transpile.js
+++ b/packages/ui5-task-transpile/lib/transpile.js
@@ -18,7 +18,7 @@ module.exports = function({workspace, dependencies, options}) {
     const plugins = []
       .concat(
         options.configuration && options.configuration.removeConsoleStatements
-          ? "transform-remove-console"
+          ? [[ "transform-remove-console" ]]
           : []
       )
       .concat(

--- a/packages/ui5-task-transpile/lib/transpile.js
+++ b/packages/ui5-task-transpile/lib/transpile.js
@@ -18,16 +18,18 @@ module.exports = function({workspace, dependencies, options}) {
     const plugins = []
       .concat(
         options.configuration && options.configuration.removeConsoleStatements
-          ? [[ "transform-remove-console" ]]
+          ? [["transform-remove-console"]]
           : []
       )
       .concat(
         options.configuration && options.configuration.transpileAsync
           ? [
-              "babel-plugin-transform-async-to-promises",
-              {
-                inlineHelpers: true,
-              },
+              [
+                "babel-plugin-transform-async-to-promises",
+                {
+                  inlineHelpers: true,
+                },
+              ],
             ]
           : []
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,6 +2385,11 @@ babel-plugin-dynamic-import-node@^2.3.3:
   dependencies:
     object.assign "^4.1.0"
 
+babel-plugin-transform-async-to-promises@^0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
+  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
+
 babel-plugin-transform-remove-console@^6.9.4:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6541,7 +6541,7 @@ lodash.map@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
   integrity sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=
 
-lodash.merge@^4.4.0:
+lodash.merge@^4.4.0, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==


### PR DESCRIPTION
This PR implements the configuration option `babelConfig` in both `ui5-task-transpile` and `ui5-middleware-livetranspile`.

If set, the option `babelConfig` makes sure both packages will discard their default babel configuration and use whatever is given in `babelConfig`. Like this the user has full control over how exactly the code is transpiled.

The documentation of both packages has been enhanced accordingly.
Also the `ui5-app` has been given a sample babel configuration though I'm not sure if that's really necessary.