### PR TITLE
feat(simpleproxy): allow to increase payload limit

### DIFF
--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -67,6 +67,12 @@ server:
     afterMiddleware: compression
     configuration:
       baseUri: "https://latest-openui5.rikosjett.com"
+  - name: ui5-middleware-simpleproxy
+    mountPath: /ui5
+    afterMiddleware: compression
+    configuration:
+      baseUri: "https://sapui5.hana.ondemand.com/"
+      limit: "5mb"
   - name: ui5-middleware-livetranspile
     afterMiddleware: compression
     configuration:

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -14,6 +14,10 @@ npm install ui5-middleware-simpleproxy --save-dev
   The baseUri to proxy. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_BASEURI` environment variable.
 - strictSSL: `boolean`
   Ignore strict SSL checks. Default value `true`. Can also be set using the `UI5_MIDDLEWARE_SIMPLE_PROXY_STRICT_SSL` environment variable.
+- limit: `string`
+  This sets the body size limit (default: `1mb`). If the body size is larger than the specified (or default) limit,
+  a `413 Request Entity Too Large`  error will be returned. See [bytes.js](https://www.npmjs.com/package/bytes) for
+  a list of supported formats.
 
 In general, use of environment variables or values set in a `.env` file will override configuration values in the `ui5.yaml`.
 

--- a/packages/ui5-middleware-simpleproxy/lib/proxy.js
+++ b/packages/ui5-middleware-simpleproxy/lib/proxy.js
@@ -7,7 +7,8 @@ dotenv.config();
 const env = {
   baseUri: process.env.UI5_MIDDLEWARE_SIMPLE_PROXY_BASEURI,
   strictSSL: process.env.UI5_MIDDLEWARE_SIMPLE_PROXY_STRICT_SSL,
-  httpHeaders: process.env.UI5_MIDDLEWARE_HTTP_HEADERS
+  httpHeaders: process.env.UI5_MIDDLEWARE_HTTP_HEADERS,
+  limit: process.env.UI5_MIDDLEWARE_LIMIT
 };
 
 /**
@@ -92,10 +93,12 @@ module.exports = function ({ resources, options }) {
   if (path && path.endsWith("/")) {
     path = path.slice(0, -1);
   }
+  const limit = env.limit || (options.configuration && options.configuration.limit);
 
   // run the proxy middleware based on the baseUri configuration
   return proxy(baseUri, {
     https: protocol === "https",
+    limit: limit,
     preserveHostHdr: false,
     proxyReqOptDecorator: function (proxyReqOpts) {
       if (providedStrictSSL === false) {


### PR DESCRIPTION
Additional configuration option "limit" in `ui5.yaml`:

```yaml
  - name: ui5-middleware-simpleproxy
    mountPath: /ui5
    afterMiddleware: compression
    configuration:
      baseUri: "https://sapui5.hana.ondemand.com/"
      limit: "5mb"
```

Fixes: https://github.com/petermuessig/ui5-ecosystem-showcase/issues/293