### PR TITLE
feat(simpleproxy) allow to remove the ETag from the response

### DIFF
--- a/packages/ui5-app/ui5.yaml
+++ b/packages/ui5-app/ui5.yaml
@@ -73,6 +73,7 @@ server:
     configuration:
       baseUri: "https://sapui5.hana.ondemand.com/"
       limit: "5mb"
+      removeETag: true
   - name: ui5-middleware-livetranspile
     afterMiddleware: compression
     configuration:

--- a/packages/ui5-middleware-simpleproxy/README.md
+++ b/packages/ui5-middleware-simpleproxy/README.md
@@ -18,6 +18,8 @@ npm install ui5-middleware-simpleproxy --save-dev
   This sets the body size limit (default: `1mb`). If the body size is larger than the specified (or default) limit,
   a `413 Request Entity Too Large`  error will be returned. See [bytes.js](https://www.npmjs.com/package/bytes) for
   a list of supported formats.
+- removeETag:  `boolean`
+  Removes the ETag header from the response to avoid conditional requests.
 
 In general, use of environment variables or values set in a `.env` file will override configuration values in the `ui5.yaml`.
 


### PR DESCRIPTION
```yaml
server:
  customMiddleware:
  - name: ui5-middleware-simpleproxy
    afterMiddleware: compression
    mountPath: /odata
    configuration:
      baseUri: "http://services.odata.org"
      removeETag: true
```

Fixes: https://github.com/petermuessig/ui5-ecosystem-showcase/issues/292