### PR TITLE
feat: allow for file patterns as JS input source

### DIFF
--- a/packages/ui5-middleware-livetranspile/lib/livetranspile.js
+++ b/packages/ui5-middleware-livetranspile/lib/livetranspile.js
@@ -24,60 +24,71 @@ fileNotFoundError.file = ""
  * @returns {function} Middleware function to use
  */
 module.exports = function ({ resources, options }) {
-    const plugins =
-        options.configuration && options.configuration.transpileAsync
-            ? [
+    const config = options.configuration || {}
+    const plugins = config.transpileAsync
+        ? [
+              [
+                  "babel-plugin-transform-async-to-promises",
+                  {
+                      inlineHelpers: true
+                  }
+              ]
+          ]
+        : []
+    const babelConfig = config.babelConfig
+        ? config.babelConfig
+        : {
+              sourceMaps: "inline",
+              plugins,
+              presets: [
                   [
-                      "babel-plugin-transform-async-to-promises",
+                      "@babel/preset-env",
                       {
-                          inlineHelpers: true
+                          targets: {
+                              browsers: "last 2 versions, ie 10-11"
+                          }
                       }
                   ]
               ]
-            : []
-    const babelConfig =
-        options.configuration && options.configuration.babelConfig
-            ? options.configuration.babelConfig
-            : {
-                  sourceMaps: "inline",
-                  plugins,
-                  presets: [
-                      [
-                          "@babel/preset-env",
-                          {
-                              targets: {
-                                  browsers: "last 2 versions, ie 10-11"
-                              }
-                          }
-                      ]
-                  ]
-              }
-
+          }
+    const filePatternConfig = config.filePattern || ".js"
     return (req, res, next) => {
         if (
             req.path &&
             req.path.endsWith(".js") &&
             !req.path.includes("resources/") &&
-            !((options.configuration && options.configuration.excludePatterns) || []).some((pattern) =>
-                req.path.includes(pattern)
-            )
+            !(config.excludePatterns || []).some((pattern) => req.path.includes(pattern))
         ) {
             const pathname = parseurl(req).pathname
+            const pathWithPattern = pathname.replace(".js", filePatternConfig)
 
             // grab the file via @ui5/fs.AbstractReader API
             return resources.rootProject
-                .byPath(pathname)
-                .then((resource) => {
-                    options.configuration && options.configuration.debug && log.info(`handling ${req.path}...`)
-                    if (!resource) {
-                        fileNotFoundError.file = pathname
+                .byGlob(pathWithPattern)
+                .then((resources) => {
+                    config.debug && log.info(`handling ${req.path}...`)
+
+                    if (!resources || !resources.length) {
+                        fileNotFoundError.file = pathWithPattern
                         throw fileNotFoundError
                     }
+
+                    // prefer js over other extensions, otherwise grab first possible path
+                    const resource = resources.find((r) => r.getPath() === pathname) || resources[0]
+                    if (resources.length > 1) {
+                        log.warn(
+                            `found more than 1 file for given pattern (${filePatternConfig}): ${resources
+                                .map((r) => r.getPath())
+                                .join(", ")} `
+                        )
+                        log.info(`using: ${resource.getPath()}`)
+                    }
+
                     // read file into string
                     return resource.getString()
                 })
                 .then((source) => {
-                    options.configuration && options.configuration.debug ? log.info(`...${pathname} transpiled!`) : null
+                    config.debug ? log.info(`...${pathname} transpiled!`) : null
                     const babelConfigForFile = merge({}, babelConfig, {
                         filename: pathname // necessary for source map <-> source assoc
                     })

--- a/packages/ui5-task-transpile/ui5.yaml
+++ b/packages/ui5-task-transpile/ui5.yaml
@@ -1,4 +1,4 @@
-# https://sap.github.io/ui5-tooling/pages/extensibility/CustomServerMiddleware/
+# https://sap.github.io/ui5-tooling/pages/extensibility/CustomTasks/
 specVersion: '1.0'
 metadata:
   name: ui5-task-transpile


### PR DESCRIPTION
This PR affects ui5-middleware-livetranspile as well as ui5-task-transpile.
It allows for Babel consumption of different file types other than JS.
See #359 

By default only JS files are considered. The pattern for file lookup can be configured in `ui5.yaml` via attribute `filePattern`, e.g.:  ```filePattern: ".{js,ts}"```

### Caveat
ui5-task-transpile will emit the source files for transpilation, e.g. Component.ts, in addition to the transpiled JS files.
Can be worked around by adding rimraf to the build script in package.json:

```
"scripts": {
    "serve": "ui5 serve",
    "build": "ui5 build && rimraf dist/**/*.ts"
  }
```
Are there better ways to make this happen by means of the UI5 tooling API?