### PR TITLE
Adding a second filter criteria

### DIFF
--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -31,7 +31,7 @@ module.exports = function ({ resources, options }) {
     xsappConfig.authenticationMethod = "none";
 
     let regExes = [];
-    xsappConfig.routes = xsappConfig.routes.filter((route) => !route.localDir); //ignore local routes as they are already hosted by the ui5 tooling
+    xsappConfig.routes = xsappConfig.routes.filter((route) => !route.localDir && !route.service); //ignore routes that point to web apps as they are already hosted by the ui5 tooling
 
     xsappConfig.routes.forEach(route => {
         route.authenticationType = "none";


### PR DESCRIPTION
Ignore routes that point to the HTML5 app repo like:
```
{
"source": "^(.*)",
      "target": "$1",
      "authenticationType": "xsuaa",
      "service": "html5-apps-repo-rt"
    }
```


