### PR TITLE
tests: adjust to updated wdi5 (fixes #443)

### DIFF
--- a/packages/ui5-app/package.json
+++ b/packages/ui5-app/package.json
@@ -64,7 +64,7 @@
     "ui5-task-transpile": "^0.3.0",
     "ui5-task-zipper": "^0.4.1",
     "wdio-chromedriver-service": "^6.0.4",
-    "wdio-ui5-service": "^0.1.5"
+    "wdio-ui5-service": "^0.1.9"
   },
   "ui5": {
     "dependencies": [

--- a/packages/ui5-app/webapp/test/e2e-wdi5/pages/Main.js
+++ b/packages/ui5-app/webapp/test/e2e-wdi5/pages/Main.js
@@ -2,7 +2,7 @@ const Page = require("./Page")
 
 class Main extends Page {
     open() {
-        super.open(`#/`)
+        super.open("#/")
     }
 
     _viewName = "test.Sample.view.Main"

--- a/packages/ui5-app/webapp/test/e2e-wdi5/pages/Page.js
+++ b/packages/ui5-app/webapp/test/e2e-wdi5/pages/Page.js
@@ -1,5 +1,5 @@
 module.exports = class Page {
     open(sHash) {
-        browser.goTo({sHash: `index.html${sHash}`})
+        browser.goTo({sHash: `${sHash}`})
     }
 }

--- a/packages/ui5-app/webapp/test/e2e-wdi5/tests.test.js
+++ b/packages/ui5-app/webapp/test/e2e-wdi5/tests.test.js
@@ -56,7 +56,7 @@ describe("binding", () => {
 // this suite implemented straigh-fwd, no page objects
 describe("interaction", () => {
     it("should manually allow date input", () => {
-        browser.goTo({ sHash: "index.html#/" })
+        browser.goTo({ sHash: "#/" })
 
         const oDateTimePicker = browser.asControl(dateTimePicker)
         oDateTimePicker.focus()

--- a/packages/ui5-app/webapp/test/e2e-wdi5/tests.test.js
+++ b/packages/ui5-app/webapp/test/e2e-wdi5/tests.test.js
@@ -48,7 +48,7 @@ describe("binding", () => {
         browser.asControl(navFwdButton).firePress()
 
         const oList = browser.asControl(list)
-        const aListItems = oList.getAggregation("items")
+        const aListItems = oList.getItems() // ui5 api
         expect(aListItems.length).toBeGreaterThanOrEqual(1)
     })
 })
@@ -63,7 +63,8 @@ describe("interaction", () => {
         oDateTimePicker.setValue("2020-11-11")
         // tmp change focus to different control in order to 
         // trigger ui5 framework events (e.g. date formatting)
-        browser.asControl(navFwdButton).focus() 
+        browser.keys("Tab")
+        browser.asControl(navFwdButton).focus() // ui5 api
         expect(oDateTimePicker.getValue()).toMatch(/2020/)
         expect(oDateTimePicker.getValue()).toMatch(/11/)
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -11782,7 +11782,7 @@ wdio-chromedriver-service@^6.0.4:
   dependencies:
     fs-extra "^9.0.0"
 
-wdio-ui5-service@^0.1.5:
+wdio-ui5-service@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/wdio-ui5-service/-/wdio-ui5-service-0.1.9.tgz#0c9029d06eaca0bc7067c66e117fa0792fcf6601"
   integrity sha512-VQ3YpdOqqllcru4N8yBDpva8pTChtlZtw4aeBM804Nd7pcYAdvAnu/+GzyHZixEiTJTr9rmzfwH1ef1Xbg8i8g==


### PR DESCRIPTION
`wdi5` now works with both ui5-tooling- and other web-servers, respecting a default directory index file - 
thus "index" is moved to `wdi5` config time and doesn't have to be manually called in tests any more.

fixes #443 