### PR TITLE
fix: non-specified exclusions crash the server

### DIFF
--- a/packages/ui5-middleware-livereload/lib/livereload.js
+++ b/packages/ui5-middleware-livereload/lib/livereload.js
@@ -46,7 +46,10 @@ module.exports = async ({ resources, options }) => {
         watchPath = options.configuration.watchPath || options.configuration.path;
     }
     let exclusions = [];
-    const aOptExclusions = options.configuration.exclusions;
+    let aOptExclusions;
+    if (options.configuration && options.configuration.exclusions) {
+        aOptExclusions = options.configuration.exclusions;
+    }
     if (options.configuration && aOptExclusions && Array.isArray(aOptExclusions)) {
         // multilpe exclusions
         aOptExclusions.forEach((exclusion) => {


### PR DESCRIPTION
if no configuration at all is specified, the middleware used to crash `ui5 serve`.
(we'll optional-chain such cases once node 14 lts is more widely adopted)