### PR TITLE
Add auth to routes

### DIFF
--- a/packages/ui5-middleware-cfdestination/README.md
+++ b/packages/ui5-middleware-cfdestination/README.md
@@ -53,6 +53,7 @@ server:
       afterMiddleware: compression
       configuration:
         authenticationMethod: none # none or route default is none
+        allowServices: false # allows sap services like SAP iot to be used 
         debug: true
         port: 1091
         xsappJson: "xs-app.json"

--- a/packages/ui5-middleware-cfdestination/README.md
+++ b/packages/ui5-middleware-cfdestination/README.md
@@ -52,8 +52,8 @@ server:
     - name: ui5-middleware-cfdestination
       afterMiddleware: compression
       configuration:
-        authenticationMethod: none # none or route default is none
-        allowServices: false # allows sap services like SAP iot to be used 
+        authenticationMethod: "none" # "none" || "route", default: "none"
+        allowServices: false # allows sap services like SAP IoT to be used 
         debug: true
         port: 1091
         xsappJson: "xs-app.json"

--- a/packages/ui5-middleware-cfdestination/README.md
+++ b/packages/ui5-middleware-cfdestination/README.md
@@ -52,6 +52,7 @@ server:
     - name: ui5-middleware-cfdestination
       afterMiddleware: compression
       configuration:
+        authenticationMethod: none # none or route
         debug: true
         port: 1091
         xsappJson: "xs-app.json"

--- a/packages/ui5-middleware-cfdestination/README.md
+++ b/packages/ui5-middleware-cfdestination/README.md
@@ -52,7 +52,7 @@ server:
     - name: ui5-middleware-cfdestination
       afterMiddleware: compression
       configuration:
-        authenticationMethod: none # none or route
+        authenticationMethod: none # none or route default is none
         debug: true
         port: 1091
         xsappJson: "xs-app.json"

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -25,16 +25,15 @@ module.exports = function ({ resources, options }) {
     const xsappConfig = JSON.parse(fs.readFileSync(options.configuration.xsappJson, 'utf8'));
     const xsappPath = options.configuration.xsappJson.replace("xs-app.json", "");
 
-    // the embedded approuter (the one that runs locally) will ignore all auth mechanisms. 
-    // Even when xsappConfig.authenticationMethod = "route" and only define the routes, 
-    // the approuter will try to read the env var during startup - and fail if they are missing
-    xsappConfig.authenticationMethod = "none";
+    // the default auth mechanism is set to none but the user can pass an auth method using the options
+    xsappConfig.authenticationMethod = options.configuration.authenticationMethod || "none";
 
     let regExes = [];
     xsappConfig.routes = xsappConfig.routes.filter((route) => !route.localDir && !route.service); //ignore routes that point to web apps as they are already hosted by the ui5 tooling
 
     xsappConfig.routes.forEach(route => {
-        route.authenticationType = "none";
+        /* Authentication type should come from route or be set to none as default */
+        route.authenticationType = route.authenticationType || "none";
         // ignore /-redirects (e.g. "^/(.*)"
         // a source declaration such as "^/backend/(.*)$" is needed
         if (route.source.match(/.*\/.*\/.*/)) {

--- a/packages/ui5-middleware-cfdestination/lib/cfdestination.js
+++ b/packages/ui5-middleware-cfdestination/lib/cfdestination.js
@@ -29,7 +29,8 @@ module.exports = function ({ resources, options }) {
     xsappConfig.authenticationMethod = options.configuration.authenticationMethod || "none";
 
     let regExes = [];
-    xsappConfig.routes = xsappConfig.routes.filter((route) => !route.localDir && !route.service); //ignore routes that point to web apps as they are already hosted by the ui5 tooling
+    xsappConfig.routes = xsappConfig.routes
+        .filter((route) => !route.localDir && (options.configuration.allowServices || !route.service)); //ignore routes that point to web apps as they are already hosted by the ui5 tooling
 
     xsappConfig.routes.forEach(route => {
         /* Authentication type should come from route or be set to none as default */


### PR DESCRIPTION
Add auth support. 

The user can pass the authenticationMethod via the options 
and the authentication method defined in the routes is respected and used